### PR TITLE
Enable pyrit to compile and run better on non-x86 machines

### DIFF
--- a/cpyrit/_cpyrit_cpu.c
+++ b/cpyrit/_cpyrit_cpu.c
@@ -40,6 +40,7 @@
 #include <pcap.h>
 #include "cpufeatures.h"
 #include "_cpyrit_cpu.h"
+#include <sys/auxv.h>
 #ifdef COMPILE_AESNI
     #include <wmmintrin.h>
 #endif
@@ -2409,7 +2410,7 @@ static void pathconfig(void)
     #endif
 
     if (!PlatformString)
-        PlatformString = PyString_FromString("x86");
+        PlatformString = PyString_FromString((char *) getauxval(AT_PLATFORM));
     if (!prepare_pmk)
         prepare_pmk = prepare_pmk_openssl;
     if (!finalize_pmk)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ from distutils.core import setup, Extension
 from distutils.command.build_ext import build_ext
 from distutils.unixccompiler import UnixCCompiler
 from distutils.errors import CompileError
+import platform
 import subprocess
 import sys
 import re
@@ -35,7 +36,8 @@ UnixCCompiler.src_extensions.append('.S')
 EXTRA_COMPILE_ARGS = ['-Wall', '-fno-strict-aliasing', \
                       '-DVERSION="%s"' % (VERSION,)]
 # Support for AES-NI-intrinsics is not found everyhwere
-if sys.platform in ('darwin', 'linux2'):
+if sys.platform in ('darwin', 'linux2') and \
+   platform.machine() in ('x86_64', 'i386'):
     EXTRA_COMPILE_ARGS.extend(('-maes', '-mpclmul'))
 
 


### PR DESCRIPTION
Pyrit is currently broken on non-x86 machines. It does even compile. These patches enable  pyrit to build and run on non x86, as Power and ARM architecture.

This is the problem I am facing when compiling it on non-x86:

powerpc64le-linux-gnu-gcc: error: unrecognized command line option ‘-maes’
powerpc64le-linux-gnu-gcc: error: unrecognized command line option ‘-mpclmul’

This PR closes issue #488.