### PR TITLE
Master

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Changes since 0.4.0
+ * Added use_CUDA and use_OpenCL in config file.
+ * Improved cores listing and managing.
+ * Updated Wiki and ported to GitHub.
+ * limit_cpus now disables all CPUs when set to value below 0.
+
 Changes since 0.3.0:
  * Added CPyrit-CAL++
  * Added CLI-function 'check_db'

--- a/cpyrit/config.py
+++ b/cpyrit/config.py
@@ -25,8 +25,8 @@ import sys
 
 def default_config():
     config = {'default_storage': 'file://', \
-              'use_CUDA': 'true', \
-              'use_OpenCL': 'true', \
+              'use_CUDA': 'false', \
+              'use_OpenCL': 'false', \
               'rpc_server': 'false', \
               'rpc_announce': 'true', \
               'rpc_announce_broadcast': 'false', \


### PR DESCRIPTION
Enable pyrit to compile and run better on non-x86 machines. Fix #488